### PR TITLE
Use a result type to simplify multi-statement generation

### DIFF
--- a/RobloxCS.AST/Block.cs
+++ b/RobloxCS.AST/Block.cs
@@ -12,6 +12,10 @@ public sealed class Block : AstNode {
     public static Block From(Statement stmt) {
         return new Block { Statements = [stmt] };
     }
+    
+    public static Block From(List<Statement> stmts) {
+        return new Block { Statements = stmts };
+    }
 
     public void AddStatement(Statement statement) {
         Statements.Add(statement);

--- a/RobloxCS.AST/Statements/LocalAssignmentStatement.cs
+++ b/RobloxCS.AST/Statements/LocalAssignmentStatement.cs
@@ -10,6 +10,14 @@ public sealed class LocalAssignmentStatement : Statement {
 
     public static LocalAssignmentStatement Empty() => new() { Expressions = [], Names = [], Types = [] };
 
+    public static LocalAssignmentStatement Single(string name, Expression expr, TypeInfo type) {
+        return new LocalAssignmentStatement {
+            Names = [SymbolExpression.FromString(name)],
+            Expressions = [expr],
+            Types = [type],
+        };
+    }
+
     public static LocalAssignmentStatement Naked(string name, TypeInfo type) {
         return new LocalAssignmentStatement {
             Names = [SymbolExpression.FromString(name)],

--- a/RobloxCS.Example/Class1.cs
+++ b/RobloxCS.Example/Class1.cs
@@ -3,8 +3,8 @@
 internal class Class1 {
     public int A = 0;
 
-    public int TernaryTest() {
-        return A > 4 ? 1 : 2;
+    public void TernaryTest() {
+        var v = A > 4 ? 1 : 2;
     }
 
     public int DoubleA() {

--- a/RobloxCS.Transpiler/Builders/BlockBuilder.cs
+++ b/RobloxCS.Transpiler/Builders/BlockBuilder.cs
@@ -8,10 +8,15 @@ public class BlockBuilder {
         var block = Block.Empty();
 
         ctx.PushScope();
-        var statements = syntax.Statements.Select(statement => StatementBuilder.Build(statement, ctx)).ToList();
+        var result = syntax.Statements.Select(statement => StatementBuilder.Build(statement, ctx)).Aggregate((acc, next) => {
+            acc.Add(next);
+
+            return acc;
+        });
+
         ctx.PopScope();
 
-        block.Statements = statements;
+        block.Statements = result.Statements;
 
         return block;
     }
@@ -25,8 +30,12 @@ public class BlockBuilder {
     }
 
     private static Block BuildFromBlockStmt(BlockSyntax syntax, TranspilationContext ctx) {
-        var stmts = syntax.Statements.Select(stmt => StatementBuilder.Build(stmt, ctx)).ToList();
+        var result = syntax.Statements.Select(stmt => StatementBuilder.Build(stmt, ctx)).Aggregate((acc, next) => {
+            acc.Add(next);
 
-        return new Block { Statements = stmts };
+            return acc;
+        });
+
+        return new Block { Statements = result.Statements };
     }
 }

--- a/RobloxCS.Transpiler/Builders/BuilderResult.cs
+++ b/RobloxCS.Transpiler/Builders/BuilderResult.cs
@@ -9,5 +9,11 @@ public record BuilderResult {
         Statements = statements.ToList();
     }
 
+    public void AddStatement(Statement stmt) => Statements.Add(stmt);
+    public void AddStatements(List<Statement> stmts) => Statements.AddRange(stmts);
+
     public static BuilderResult FromSingle(Statement stmt) => new([stmt]);
+    public static BuilderResult Empty() => new([]);
+
+    public BuilderResult Add(BuilderResult other) => new([..Statements, ..other.Statements]);
 }

--- a/RobloxCS.Transpiler/Builders/BuilderResult.cs
+++ b/RobloxCS.Transpiler/Builders/BuilderResult.cs
@@ -1,0 +1,13 @@
+﻿using RobloxCS.AST.Statements;
+
+namespace RobloxCS.Transpiler.Builders;
+
+public record BuilderResult {
+    public List<Statement> Statements { get; }
+
+    private BuilderResult(IEnumerable<Statement> statements) {
+        Statements = statements.ToList();
+    }
+
+    public static BuilderResult FromSingle(Statement stmt) => new([stmt]);
+}

--- a/RobloxCS.Transpiler/Builders/BuilderResultExtensions.cs
+++ b/RobloxCS.Transpiler/Builders/BuilderResultExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace RobloxCS.Transpiler.Builders;
+
+public static class BuilderResultExtensions {
+    public static BuilderResult Flatten(this IEnumerable<BuilderResult> source) {
+        return source.Aggregate((acc, next) => {
+            acc.Add(next);
+
+            return acc;
+        });
+    }
+}

--- a/RobloxCS.Transpiler/Builders/ExpressionBuilderResult.cs
+++ b/RobloxCS.Transpiler/Builders/ExpressionBuilderResult.cs
@@ -1,0 +1,24 @@
+﻿using RobloxCS.AST.Expressions;
+using RobloxCS.AST.Statements;
+
+namespace RobloxCS.Transpiler.Builders;
+
+/// <summary>
+/// Represents a result from an <see cref="ExpressionBuilder"/>.
+///
+/// The property `Statements` will not be empty if the expression has a prolog.
+/// E.g. ternary __tmp, etc. 
+/// </summary>
+public record ExpressionBuilderResult {
+    public List<Statement> Statements { get; }
+    public Expression Expression { get; set; }
+
+    private ExpressionBuilderResult(IEnumerable<Statement> statements, Expression expr) {
+        Statements = statements.ToList();
+        Expression = expr;
+    }
+
+    public void AddStatement(Statement stmt) => Statements.Add(stmt);
+
+    public static ExpressionBuilderResult FromSingle(Expression expr) => new([], expr);
+}

--- a/RobloxCS.Transpiler/Builders/FunctionBuilder.cs
+++ b/RobloxCS.Transpiler/Builders/FunctionBuilder.cs
@@ -98,7 +98,7 @@ internal static class FunctionBuilder {
             ctx.PushScope();
 
             foreach (var transpiled in body.Statements.Select(stmt => StatementBuilder.Build(stmt, ctx))) {
-                functionBlock.AddStatement(transpiled);
+                functionBlock.AddStatements(transpiled.Statements);
             }
 
             ctx.PopScope();
@@ -135,8 +135,8 @@ internal static class FunctionBuilder {
         if (syntax.Body is { } body) {
             ctx.PushScope();
 
-            foreach (var stmt in body.Statements.Select(stmt => StatementBuilder.Build(stmt, ctx))) {
-                functionBlock.AddStatement(stmt);
+            foreach (var result in body.Statements.Select(stmt => StatementBuilder.Build(stmt, ctx))) {
+                functionBlock.AddStatements(result.Statements);
             }
 
             ctx.PopScope();


### PR DESCRIPTION
All builders return a singular object of what they're building. This is an issue for context-sensitive actions like ternary, especially nested ternaries.



This PR aims to fix that with a `BuilderResult` which contains a `prolog` - a list of statements appearing before the resulting expression/statement.

